### PR TITLE
Automatically convert DateTimes to UTC

### DIFF
--- a/lib/neo4j/type_converters/type_converters.rb
+++ b/lib/neo4j/type_converters/type_converters.rb
@@ -214,9 +214,10 @@ module Neo4j
         end
 
         # Converts the given DateTime (UTC) value to an Fixnum.
-        # Only utc times are supported !
+        # DateTime values are automatically converted to UTC.
         def to_java(value)
           return nil if value.nil?
+          value = value.new_offset(0) if value.respond_to?(:new_offset)
           if value.class == Date
             Time.utc(value.year, value.month, value.day, 0, 0, 0).to_i
           else
@@ -274,7 +275,7 @@ module Neo4j
       def converters=(converters)
         @converters = converters
       end
-      
+
       # Always returns a converter that handles to_ruby or to_java
       # if +enforce_type+ is set to false then it will raise in case of unknown type
       # otherwise it will return the DefaultConverter.

--- a/spec/neo4j/type_converters/datetime_converter_spec.rb
+++ b/spec/neo4j/type_converters/datetime_converter_spec.rb
@@ -33,6 +33,11 @@ describe "Date and Time converters" do
 
 
   describe "DateTime" do
+    before(:each) do
+      @dt = 1352538487
+      @hr = 3600
+    end
+
     subject { Neo4j::TypeConverters::DateTimeConverter }
 
     its(:convert?, DateTime)  { should be_true }
@@ -42,7 +47,14 @@ describe "Date and Time converters" do
 
     its(:to_java, nil)        { should be_nil }
     its(:to_ruby, nil)        { should be_nil }
-  end
 
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07-06:00")) { should === @dt + 6*@hr }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07-04:00")) { should === @dt + 4*@hr }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07-02:00")) { should === @dt + 2*@hr }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07+00:00")) { should === @dt }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07+02:00")) { should === @dt - 2*@hr }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07+04:00")) { should === @dt - 4*@hr }
+    its(:to_java, DateTime.parse("2012-11-10T09:08:07+06:00")) { should === @dt - 6*@hr }
+  end
 
 end


### PR DESCRIPTION
In DateTimeConverter#to_java, if the given value is a DateTime, it is
automatically converted to UTC using DateTime#new_offset(0). Date and
Time objects are left alone, since they don't respond to new_offset.

Spec tests included.
