### PR TITLE
Allow string class name to be passed in to #relationship helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ source :gemcutter
 gemspec
 
 group 'test' do
-  # for string constantize in tests:
-  gem "i18n"
-  gem "active_support"
-
   gem "rake", ">= 0.8.7"
   gem "rspec", "~> 2.8"
   gem "its" # its(:with, :arguments) { should be_possible }

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source :gemcutter
 gemspec
 
 group 'test' do
+  # for string constantize in tests:
+  gem "i18n"
+  gem "active_support"
+
   gem "rake", ">= 0.8.7"
   gem "rspec", "~> 2.8"
   gem "its" # its(:with, :arguments) { should be_possible }

--- a/lib/neo4j-wrapper/has_n/decl_rel.rb
+++ b/lib/neo4j-wrapper/has_n/decl_rel.rb
@@ -217,7 +217,7 @@ module Neo4j
             other_class_dsl = target_class && target_class._decl_rels[@relationship_name]
             @relationship = other_class_dsl.relationship_class if other_class_dsl
           end
-          @relationship = @relationship.constantize if @relationship.is_a? String
+          @relationship = Neo4j::Wrapper.method(:to_class).call(@relationship) if @relationship.is_a? String
           @relationship
         end
 

--- a/lib/neo4j-wrapper/has_n/decl_rel.rb
+++ b/lib/neo4j-wrapper/has_n/decl_rel.rb
@@ -192,7 +192,9 @@ module Neo4j
         #   class Order
         #     property :total_cost
         #     property :dispatched
-        #     has_n(:products).to(Product).relationship(OrderLine)
+        #     has_n(:products).to(Product).relationship(OrderLine)                
+        #     # strings can also be passed in, for cases where the class may not be initialized yet:
+        #     # has_n(:products).to(Product).relationship('Order::Line')
         #   end
         #
         #  order = Order.new

--- a/lib/neo4j-wrapper/has_n/decl_rel.rb
+++ b/lib/neo4j-wrapper/has_n/decl_rel.rb
@@ -214,7 +214,8 @@ module Neo4j
           if @dir == :incoming
             other_class_dsl = target_class && target_class._decl_rels[@relationship_name]
             @relationship = other_class_dsl.relationship_class if other_class_dsl
-           end
+          end
+          @relationship = @relationship.constantize if @relationship.is_a? String
           @relationship
         end
 

--- a/spec/neo4j-wrapper/has_n/decl_rel_spec.rb
+++ b/spec/neo4j-wrapper/has_n/decl_rel_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support/core_ext/string/inflections'
 
 describe Neo4j::Wrapper::HasN::DeclRel do
 

--- a/spec/neo4j-wrapper/has_n/decl_rel_spec.rb
+++ b/spec/neo4j-wrapper/has_n/decl_rel_spec.rb
@@ -1,34 +1,14 @@
 require 'spec_helper'
-
+require 'active_support/core_ext/string/inflections'
 
 describe Neo4j::Wrapper::HasN::DeclRel do
 
-  let(:original_target_class) do
-    Class.new do
-      def self.to_s
-        "OriginalTargetClass"
-      end
-    end
-  end
-
-  let(:new_target_class) do
-    Class.new do
-      def self.to_s
-        "NewTargetClass"
-      end
-    end
-  end
+  class OriginalTargetClass; end
+  class NewTargetClass; end
+  class RelationClass; end
 
   let(:decl_rel) do
-    Neo4j::Wrapper::HasN::DeclRel.new(:friends, false, original_target_class)
-  end
-
-  let(:relation_class) do
-    Class.new do
-      def self.to_s
-        "MyRelationship"
-      end
-    end
+    Neo4j::Wrapper::HasN::DeclRel.new(:friends, false, OriginalTargetClass)
   end
 
   describe "#create_relationship_to" do
@@ -67,9 +47,16 @@ describe Neo4j::Wrapper::HasN::DeclRel do
 
   describe "#relationship(a_class)" do
     subject do
-      decl_rel.relationship(relation_class)
+      decl_rel.relationship(RelationClass)
     end
-    its(:relationship_class) { should == relation_class }
+    its(:relationship_class) { should == RelationClass }
+  end
+
+  describe "#relationship(a_class_string)" do
+    subject do
+      decl_rel.relationship('RelationClass')
+    end
+    its(:relationship_class) { should == RelationClass }
   end
 
   describe "#from" do
@@ -81,7 +68,7 @@ describe Neo4j::Wrapper::HasN::DeclRel do
       its(:rel_type) { should == :other }
       its(:dir) { should == :incoming }
       its(:target_class) { should be_nil }
-      its(:source_class) { should == original_target_class }
+      its(:source_class) { should == OriginalTargetClass }
       its(:relationship_class) { should be_nil }
     end
 
@@ -101,9 +88,9 @@ describe Neo4j::Wrapper::HasN::DeclRel do
       its(:rel_type) { should == :'FromClass#other' }
       its(:dir) { should == :incoming }
       its(:target_class) { should == from_class }
-      its(:source_class) { should == original_target_class }
+      its(:source_class) { should == OriginalTargetClass }
       it "relationship_class should use the incoming relationship_class" do
-        other = Neo4j::Wrapper::HasN::DeclRel.new(:other, false, original_target_class)
+        other = Neo4j::Wrapper::HasN::DeclRel.new(:other, false, OriginalTargetClass)
         other.relationship(Class.new)
         from_decl_rels = {:other => other}
         from_class.should_receive(:_decl_rels).and_return(from_decl_rels)
@@ -124,19 +111,19 @@ describe Neo4j::Wrapper::HasN::DeclRel do
       its(:rel_type) { should == :bar }
       its(:dir) { should == :outgoing }
       its(:target_class) { should be_nil }
-      its(:source_class) { should == original_target_class }
+      its(:source_class) { should == OriginalTargetClass }
       its(:relationship_class) { should be_nil }
     end
 
     context "to(Class)" do
       subject do
-        decl_rel.to(new_target_class)
+        decl_rel.to(NewTargetClass)
       end
 
       its(:rel_type) { should == :"OriginalTargetClass#friends" }
       its(:dir) { should == :outgoing }
-      its(:target_class) { should == new_target_class }
-      its(:source_class) { should == original_target_class }
+      its(:target_class) { should == NewTargetClass }
+      its(:source_class) { should == OriginalTargetClass }
       its(:relationship_class) { should be_nil }
     end
 


### PR DESCRIPTION
This allows the syntax:

``` ruby
  has_n(:products).to(Product).relationship('Order::Line')
```

Which is important especially for namespaced relationships.  Otherwise, UninitializedConstant errors would be thrown.

Note that there were more changes to the test suite (which passes now with +1 test) than to the acutal source.
- There is an additional test for this case.
- How classes are asserted has changed.  Before, an instance of a class with to_s implemented would be compared.  This caused issues with the class instances being compared but not equated (`Diff:Class.==(Class) returned false even though the diff between Class and Class is empty. Check the implementation of Class.==.`)  This change simplifies and reads better, so I figured it was a good way to go.
